### PR TITLE
Change handling regions in AVM examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
@@ -44,7 +42,7 @@ The following resources are used by this module:
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
-- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/uuid) (resource)
+- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
+- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
+
 ## Resources
 
 The following resources are used by this module:
@@ -42,7 +44,7 @@ The following resources are used by this module:
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
-- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/uuid) (resource)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -40,7 +40,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -31,21 +27,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -54,7 +35,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -88,14 +69,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -122,6 +100,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"uksouth"`
+
 ## Outputs
 
 No outputs.
@@ -133,12 +119,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: ~> 0.3
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: ~> 0.3
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -25,21 +21,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -48,7 +29,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -34,7 +34,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "uksouth"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/examples/diagnostic_settings/README.md
+++ b/examples/diagnostic_settings/README.md
@@ -54,7 +54,6 @@ resource "azurerm_log_analytics_workspace" "diag2" {
   resource_group_name = azurerm_resource_group.this.name
 }
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/diagnostic_settings/README.md
+++ b/examples/diagnostic_settings/README.md
@@ -14,10 +14,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -34,21 +30,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -57,7 +38,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "East US 2"
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -79,8 +60,7 @@ resource "azurerm_log_analytics_workspace" "diag2" {
 module "test" {
   source = "../../"
 
-  location = "eastus2" # diagnostic settings are not available in all regions
-  # location            = azurerm_resource_group.this.location
+  location            = var.location
   name                = module.naming.api_management.name_unique
   publisher_email     = var.publisher_email
   resource_group_name = azurerm_resource_group.this.name
@@ -119,8 +99,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
@@ -128,7 +106,6 @@ The following resources are used by this module:
 - [azurerm_log_analytics_workspace.diag](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_log_analytics_workspace.diag2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -155,6 +132,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"eastus2"`
+
 ## Outputs
 
 No outputs.
@@ -166,12 +151,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: ~> 0.3
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: ~> 0.3
 

--- a/examples/diagnostic_settings/main.tf
+++ b/examples/diagnostic_settings/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -25,21 +21,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -48,7 +29,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "East US 2"
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -70,8 +51,7 @@ resource "azurerm_log_analytics_workspace" "diag2" {
 module "test" {
   source = "../../"
 
-  location = "eastus2" # diagnostic settings are not available in all regions
-  # location            = azurerm_resource_group.this.location
+  location            = var.location
   name                = module.naming.api_management.name_unique
   publisher_email     = var.publisher_email
   resource_group_name = azurerm_resource_group.this.name

--- a/examples/diagnostic_settings/main.tf
+++ b/examples/diagnostic_settings/main.tf
@@ -45,7 +45,6 @@ resource "azurerm_log_analytics_workspace" "diag2" {
   resource_group_name = azurerm_resource_group.this.name
 }
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/diagnostic_settings/variables.tf
+++ b/examples/diagnostic_settings/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "eastus2"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/examples/multiple_locations/README.md
+++ b/examples/multiple_locations/README.md
@@ -40,7 +40,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/multiple_locations/README.md
+++ b/examples/multiple_locations/README.md
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -31,21 +27,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -54,7 +35,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = "uksouth"
   name     = module.naming.resource_group.name_unique
 }
 
@@ -95,14 +76,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -140,12 +118,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: ~> 0.3
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: ~> 0.3
 

--- a/examples/multiple_locations/main.tf
+++ b/examples/multiple_locations/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -25,21 +21,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -48,7 +29,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = "uksouth"
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/multiple_locations/main.tf
+++ b/examples/multiple_locations/main.tf
@@ -34,7 +34,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
@@ -13,10 +13,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -32,18 +28,6 @@ provider "azurerm" {
   }
 }
 
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.3.0"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -53,7 +37,7 @@ data "azurerm_client_config" "current" {}
 
 
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -179,8 +163,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
@@ -212,7 +194,6 @@ The following resources are used by this module:
 - [azurerm_subnet_network_security_group_association.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) (resource)
 - [azurerm_user_assigned_identity.cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -239,6 +220,14 @@ If it is set to false, then no telemetry will be collected.
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"eastus"`
 
 ## Outputs
 
@@ -299,12 +288,6 @@ Version: 0.3.0
 Source: Azure/avm-res-network-privatednszone/azurerm
 
 Version: ~> 0.2
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/avm-utl-regions/azurerm
-
-Version: 0.3.0
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
@@ -99,7 +99,6 @@ resource "azurerm_user_assigned_identity" "cmk" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
@@ -7,10 +7,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -26,18 +22,6 @@ provider "azurerm" {
   }
 }
 
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.3.0"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -47,7 +31,7 @@ data "azurerm_client_config" "current" {}
 
 
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
@@ -93,7 +93,6 @@ resource "azurerm_user_assigned_identity" "cmk" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/variables.tf
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "eastus"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/examples/security_and_certs/README.md
+++ b/examples/security_and_certs/README.md
@@ -40,7 +40,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/security_and_certs/README.md
+++ b/examples/security_and_certs/README.md
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -31,21 +27,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -54,7 +35,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "eastus2" # module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -96,14 +77,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -130,6 +108,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"eastus2"`
+
 ## Outputs
 
 The following outputs are exported:
@@ -145,12 +131,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: ~> 0.3
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: ~> 0.3
 

--- a/examples/security_and_certs/main.tf
+++ b/examples/security_and_certs/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -25,21 +21,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -48,7 +29,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "eastus2" # module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/security_and_certs/main.tf
+++ b/examples/security_and_certs/main.tf
@@ -34,7 +34,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/security_and_certs/variables.tf
+++ b/examples/security_and_certs/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "eastus2"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/examples/system_assigned_identity/README.md
+++ b/examples/system_assigned_identity/README.md
@@ -40,7 +40,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/system_assigned_identity/README.md
+++ b/examples/system_assigned_identity/README.md
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -31,21 +27,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -54,7 +35,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "eastus2" # module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -91,14 +72,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -125,6 +103,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"eastus2"`
+
 ## Outputs
 
 The following outputs are exported:
@@ -140,12 +126,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: ~> 0.3
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: ~> 0.3
 

--- a/examples/system_assigned_identity/main.tf
+++ b/examples/system_assigned_identity/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -25,21 +21,6 @@ provider "azurerm" {
   }
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
-
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
@@ -48,7 +29,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "eastus2" # module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/system_assigned_identity/main.tf
+++ b/examples/system_assigned_identity/main.tf
@@ -34,7 +34,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/system_assigned_identity/variables.tf
+++ b/examples/system_assigned_identity/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "eastus2"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/examples/vnet_private_endpoint/README.md
+++ b/examples/vnet_private_endpoint/README.md
@@ -84,7 +84,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/vnet_private_endpoint/README.md
+++ b/examples/vnet_private_endpoint/README.md
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -30,21 +26,6 @@ provider "azurerm" {
 
   }
 }
-
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
 
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
@@ -98,7 +79,7 @@ module "private_dns_apim" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 
@@ -152,14 +133,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (3.6.2)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -186,6 +164,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
+
+Default: `"eastus2"`
+
 ## Outputs
 
 No outputs.
@@ -205,12 +191,6 @@ Version: ~> 0.3
 Source: Azure/avm-res-network-privatednszone/azurerm
 
 Version: ~> 0.2
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
-
-Version: ~> 0.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/vnet_private_endpoint/main.tf
+++ b/examples/vnet_private_endpoint/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }
 
@@ -24,21 +20,6 @@ provider "azurerm" {
 
   }
 }
-
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = "~> 0.3"
-}
-
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
 
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
@@ -92,7 +73,7 @@ module "private_dns_apim" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = module.naming.resource_group.name_unique
 }
 

--- a/examples/vnet_private_endpoint/main.tf
+++ b/examples/vnet_private_endpoint/main.tf
@@ -78,7 +78,6 @@ resource "azurerm_resource_group" "this" {
 }
 
 # This is the module call
-# Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {

--- a/examples/vnet_private_endpoint/variables.tf
+++ b/examples/vnet_private_endpoint/variables.tf
@@ -12,3 +12,10 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
+variable "location" {
+  type        = string
+  default     = "eastus2"
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}

--- a/main.diagnostics.tf
+++ b/main.diagnostics.tf
@@ -26,11 +26,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -151,12 +151,12 @@ resource "azurerm_api_management" "this" {
     for_each = var.security != null ? [var.security] : []
 
     content {
-      enable_backend_ssl30                                = security.value.enable_backend_ssl30
-      enable_backend_tls10                                = security.value.enable_backend_tls10
-      enable_backend_tls11                                = security.value.enable_backend_tls11
-      enable_frontend_ssl30                               = security.value.enable_frontend_ssl30
-      enable_frontend_tls10                               = security.value.enable_frontend_tls10
-      enable_frontend_tls11                               = security.value.enable_frontend_tls11
+      backend_ssl30_enabled                               = security.value.enable_backend_ssl30
+      backend_tls10_enabled                               = security.value.enable_backend_tls10
+      backend_tls11_enabled                               = security.value.enable_backend_tls11
+      frontend_ssl30_enabled                              = security.value.enable_frontend_ssl30
+      frontend_tls10_enabled                              = security.value.enable_frontend_tls10
+      frontend_tls11_enabled                              = security.value.enable_frontend_tls11
       tls_ecdhe_ecdsa_with_aes128_cbc_sha_ciphers_enabled = security.value.tls_ecdhe_ecdsa_with_aes128_cbc_sha_ciphers_enabled
       tls_ecdhe_ecdsa_with_aes256_cbc_sha_ciphers_enabled = security.value.tls_ecdhe_ecdsa_with_aes256_cbc_sha_ciphers_enabled
       tls_ecdhe_rsa_with_aes128_cbc_sha_ciphers_enabled   = security.value.tls_ecdhe_rsa_with_aes128_cbc_sha_ciphers_enabled

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,9 +10,5 @@ terraform {
       source  = "Azure/modtm"
       version = "~> 0.3"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "Azure/modtm"
       version = "~> 0.3"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.2"
+    }
   }
 }


### PR DESCRIPTION
## Description

I realized while testing some changes made for private endpoints that sometimes, we will fail the examples for the AVM when we are using the random module to determine which region to deploy APIM resources into. This is because APIM region support varies greatly across SKUs. 

For example:
https://learn.microsoft.com/en-us/azure/api-management/api-management-region-availability , which does not even include the new V2 SKUs. It also does not include regions where APIM is not available at all. (For example, I believe APIM is either not available in Qatar with any of the older SKUs). 

Fixes #10
Closes #10 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
