### PR TITLE
Update variables.tf to support V2 SKUs

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -431,6 +431,7 @@ variable "sku_name" {
   type        = string
   default     = "Developer_1"
   description = "The SKU name of the API Management service."
+
   validation {
     condition     = can(regex("^Consumption_0$|^Basic_(1|2)$|^BasicV2_([1-9]|10)|^Developer_1$|^Premium_([1-9][0-9]{0,1})$|^PremiumV2_([1-9]|1[0-9]|2[0-9]|30)$|^Standard_[1-4]$|^StandardV2_([1-9]|10)$", var.sku_name))
     error_message = "The sku_name must be one of: Consumption_0, Basic_1, Basic_2, BasicV2_1 through BasicV2_10, Developer_1, Premium_1 through Premium_99, PremiumV2_1 through PremiumV2_30, Standard_1 through Standard_4, or StandardV2_1 through StandardV2_10."


### PR DESCRIPTION
## Description

This change updates the validation used for the APIM SKU to match the same logic in the azurerm provider.
[SKU regex in azurerm provider](https://github.com/hashicorp/terraform-provider-azurerm/blob/e8290135a81fe384fdb03714a3d6a9dfb4be3d1a/internal/services/apimanagement/validate/api_management_sku.go#L15)

Note: To test this, you cannot use availability zones with the `PremiumV2_{number}` SKUs. 
[Zone limitation in the azurerm provider](https://github.com/hashicorp/terraform-provider-azurerm/blob/e8290135a81fe384fdb03714a3d6a9dfb4be3d1a/internal/services/apimanagement/api_management_resource.go#L912)

Test using a SKU, such as `PremiumV2_3`, and ensure `zones` is an empty array.

Fixes #3 
Closes #3

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
