### PR TITLE
Allow Private Endpoints with Internal or External Virtual Network Configurations (V2 SKUs only)

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -46,10 +46,10 @@ module "test" {
   resource_group_name = azurerm_resource_group.this.name
   enable_telemetry    = var.enable_telemetry
   publisher_name      = "Apim Example Publisher"
-  sku_name            = "PremiumV2_3"
+  sku_name            = "Premium_3"
   tags = {
     environment = "test"
     cost_center = "test"
   }
-  #zones = ["1", "2", "3"] # For compliance with WAF
+  zones = ["1", "2", "3"] # For compliance with WAF
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -46,10 +46,10 @@ module "test" {
   resource_group_name = azurerm_resource_group.this.name
   enable_telemetry    = var.enable_telemetry
   publisher_name      = "Apim Example Publisher"
-  sku_name            = "Premium_3"
+  sku_name            = "PremiumV2_3"
   tags = {
     environment = "test"
     cost_center = "test"
   }
-  zones = ["1", "2", "3"] # For compliance with WAF
+  #zones = ["1", "2", "3"] # For compliance with WAF
 }

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
@@ -87,6 +87,7 @@ module "private_dns_apim" {
   parent_id        = azurerm_resource_group.this.id
   virtual_network_links = {
     dnslink = {
+      name         = "dnslink-azure-apim"
       vnetlinkname = "privatelink-azure-api-net"
       vnetid       = azurerm_virtual_network.this.id
     }

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/README.md
@@ -82,9 +82,9 @@ module "private_dns_apim" {
   source  = "Azure/avm-res-network-privatednszone/azurerm"
   version = "~> 0.2"
 
-  domain_name         = "privatelink.azure-api.net"
-  resource_group_name = azurerm_resource_group.this.name
-  enable_telemetry    = var.enable_telemetry
+  domain_name      = "privatelink.azure-api.net"
+  enable_telemetry = var.enable_telemetry
+  parent_id        = azurerm_resource_group.this.id
   virtual_network_links = {
     dnslink = {
       vnetlinkname = "privatelink-azure-api-net"

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
@@ -81,6 +81,7 @@ module "private_dns_apim" {
   parent_id        = azurerm_resource_group.this.id
   virtual_network_links = {
     dnslink = {
+      name         = "dnslink-azure-apim"
       vnetlinkname = "privatelink-azure-api-net"
       vnetid       = azurerm_virtual_network.this.id
     }

--- a/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
+++ b/examples/preprovisioned_virtual_network_private_endpoints_with_permissions/main.tf
@@ -76,9 +76,9 @@ module "private_dns_apim" {
   source  = "Azure/avm-res-network-privatednszone/azurerm"
   version = "~> 0.2"
 
-  domain_name         = "privatelink.azure-api.net"
-  resource_group_name = azurerm_resource_group.this.name
-  enable_telemetry    = var.enable_telemetry
+  domain_name      = "privatelink.azure-api.net"
+  enable_telemetry = var.enable_telemetry
+  parent_id        = azurerm_resource_group.this.id
   virtual_network_links = {
     dnslink = {
       vnetlinkname = "privatelink-azure-api-net"

--- a/examples/vnet_private_endpoint/README.md
+++ b/examples/vnet_private_endpoint/README.md
@@ -65,12 +65,13 @@ module "private_dns_apim" {
   source  = "Azure/avm-res-network-privatednszone/azurerm"
   version = "~> 0.2"
 
-  domain_name         = "privatelink.azure-api.net"
-  resource_group_name = azurerm_resource_group.this.name
+  domain_name = "privatelink.azure-api.net"
+  parent_id   = azurerm_resource_group.this.id
   # tags             = var.tags
   enable_telemetry = var.enable_telemetry
   virtual_network_links = {
     dnslink = {
+      name         = "dnslink-azure-apim"
       vnetlinkname = "privatelink-azure-api-net"
       vnetid       = module.virtual_network.resource.id
     }

--- a/examples/vnet_private_endpoint/main.tf
+++ b/examples/vnet_private_endpoint/main.tf
@@ -29,29 +29,29 @@ module "naming" {
 }
 
 
-# Create a virtual network for testing if needed
-module "virtual_network" {
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "~> 0.8.0"
+# # Create a virtual network for testing if needed
+# module "virtual_network" {
+#   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+#   version = "~> 0.8.0"
 
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-  name                = module.naming.virtual_network.name_unique
-  subnets = {
-    default_subnet = {
-      name             = "default_subnet"
-      address_prefixes = ["10.0.1.0/24"]
-      # delegations       = {}
-    }
-    pe_subnet = {
-      name              = "pe_subnet"
-      address_prefixes  = ["10.0.2.0/24"]
-      service_endpoints = []
-      # delegations       = {}
-    }
-  }
-}
+#   address_space       = ["10.0.0.0/16"]
+#   location            = azurerm_resource_group.this.location
+#   resource_group_name = azurerm_resource_group.this.name
+#   name                = module.naming.virtual_network.name_unique
+#   subnets = {
+#     default_subnet = {
+#       name             = "default_subnet"
+#       address_prefixes = ["10.0.1.0/24"]
+#       # delegations       = {}
+#     }
+#     pe_subnet = {
+#       name              = "pe_subnet"
+#       address_prefixes  = ["10.0.2.0/24"]
+#       service_endpoints = []
+#       # delegations       = {}
+#     }
+#   }
+# }
 
 
 # Create a Private DNS Zone for API Management
@@ -66,7 +66,7 @@ module "private_dns_apim" {
   virtual_network_links = {
     dnslink = {
       vnetlinkname = "privatelink-azure-api-net"
-      vnetid       = module.virtual_network.resource.id
+      vnetid       ="/subscriptions/aa27a1b3-530a-4637-a1e6-6855033a65e5/resourceGroups/rg-ij17/providers/Microsoft.Network/virtualNetworks/vnet-ij17"
     }
   }
 }
@@ -94,7 +94,7 @@ module "test" {
   private_endpoints = {
     endpoint1 = {
       name               = "pe-${module.naming.api_management.name_unique}"
-      subnet_resource_id = module.virtual_network.subnets["pe_subnet"].resource_id
+      subnet_resource_id = "/subscriptions/aa27a1b3-530a-4637-a1e6-6855033a65e5/resourceGroups/rg-ij17/providers/Microsoft.Network/virtualNetworks/vnet-ij17/subnets/pe_subnet"
 
       # Link to the private DNS zone we created
       private_dns_zone_resource_ids = [
@@ -108,12 +108,13 @@ module "test" {
     }
   }
   publisher_name = "Apim Example Publisher"
-  sku_name       = "Premium_3"
+  sku_name       = "PremiumV2_3"
   tags = {
     environment = "test"
     cost_center = "test"
   }
-  virtual_network_type = "None"
-  zones                = ["1", "2", "3"] # For compliance with WAF
+  virtual_network_type = "External"
+  virtual_network_subnet_id = "/subscriptions/aa27a1b3-530a-4637-a1e6-6855033a65e5/resourceGroups/rg-ij17/providers/Microsoft.Network/virtualNetworks/vnet-ij17/subnets/pe_subnet"
+  #zones                = ["1", "2", "3"] # For compliance with WAF
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -308,7 +308,7 @@ DESCRIPTION
 
   validation {
     condition = length(var.private_endpoints) == 0 || (
-      var.virtual_network_type == "None" || can(regex("V2", var.sku_name))) && !startswith(var.sku_name, "Consumption")
+    var.virtual_network_type == "None" || can(regex("V2", var.sku_name))) && !startswith(var.sku_name, "Consumption")
     error_message = "Private endpoints are not supported with Consumption SKU or when using Internal/External virtual network mode (unless using a V2 SKU)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -472,14 +472,6 @@ variable "virtual_network_type" {
   }
 }
 
-variable "virtual_network_configuration" {
-  type = object({
-    subnet_id = string
-  })
-  default     = null
-  description = "Virtual network configuration for the API Management service. Required when virtual_network_type is External or Internal."
-}
-
 variable "zones" {
   type        = list(string)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -307,12 +307,9 @@ DESCRIPTION
   nullable    = false
 
   validation {
-    condition     = var.virtual_network_type == "None" || length(var.private_endpoints) == 0
-    error_message = "Private endpoints cannot be used with API Management in Internal or External virtual network mode. Use either private endpoints (with virtual_network_type = None ) or Internal/External virtual network mode."
-  }
-  validation {
-    condition     = !startswith(var.sku_name, "Consumption") || length(var.private_endpoints) == 0
-    error_message = "Private endpoints are not supported with the API Management Consumption SKU."
+    condition = length(var.private_endpoints) == 0 || (
+      var.virtual_network_type == "None" || can(regex("V2", var.sku_name))) && !startswith(var.sku_name, "Consumption")
+    error_message = "Private endpoints are not supported with Consumption SKU or when using Internal/External virtual network mode (unless using a V2 SKU)."
   }
 }
 
@@ -473,6 +470,14 @@ variable "virtual_network_type" {
     condition     = contains(["None", "External", "Internal"], var.virtual_network_type)
     error_message = "The virtual_network_type must be one of: None, External, or Internal."
   }
+}
+
+variable "virtual_network_configuration" {
+  type = object({
+    subnet_id = string
+  })
+  default     = null
+  description = "Virtual network configuration for the API Management service. Required when virtual_network_type is External or Internal."
 }
 
 variable "zones" {

--- a/variables.tf
+++ b/variables.tf
@@ -308,8 +308,8 @@ DESCRIPTION
 
   validation {
     condition = length(var.private_endpoints) == 0 || (
-    var.virtual_network_type == "None" || can(regex("V2", var.sku_name))) && !startswith(var.sku_name, "Consumption")
-    error_message = "Private endpoints are not supported with Consumption SKU or when using Internal/External virtual network mode (unless using a V2 SKU)."
+    var.virtual_network_type == "None" || can(regex("StandardV2", var.sku_name))) && !startswith(var.sku_name, "Consumption")
+    error_message = "Private endpoints are not supported with Consumption SKU or when using Internal/External virtual network mode (unless using StandardV2 SKU)."
   }
 }
 


### PR DESCRIPTION
## Description
This PR fixes the validation for private endpoint creation - there are two validations now:

1. Private Endpoints are not allowed for Consumption SKUs.
2. Private Endpoints are allowed in Internal and External mode, but only with V2 SKUs.

To test this change:
1. I utilized the `examples/vnet_private_endpoint`, commenting out the virtual network deployment and using a pre-existing virtual network. This network requires at least one subnet which is delegated to `Microsoft.Web/serverFarms`. 
2. Change settings to:
```terraform
  virtual_network_type = "External"
  virtual_network_subnet_id = {SUBNET_ID}
  #zones                = ["1", "2", "3"] # For compliance with WAF
```
3. Run `terraform plan` / `terraform apply` successfully.

Fixes #21 
Closes #21

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
