### PR TITLE
fix: validate that api.path can be either empty or not contain one of…

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,12 @@
 # Tests
 
 Create tests in the provided subdirectories.
+
+## Run Tests
+
+Run this at the root of the repository.
+
+```bash
+terraform init
+terraform test -test-directory=tests/unit
+```

--- a/tests/unit/api_path.tftest.hcl
+++ b/tests/unit/api_path.tftest.hcl
@@ -1,23 +1,24 @@
-# File: tests/unit/unit.tftest.hcl
-
 # Mock the azurerm provider to prevent real deployments
 mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "azapi" {}
+
+# Common variables for all runs
+variables {
+  name                = "test-apim-service"
+  resource_group_name = "test-rg"
+  location            = "eastus"
+  publisher_email     = "admin@example.com"
+  publisher_name      = "Example Publisher"
+  sku_name            = "Developer_1"
+}
 
 run "validate_empty_api_path" {
   command = plan
 
   # This should succeed if an empty api path is supported
 
-  variables {
-    name                = "test-apim-service"
-    resource_group_name = "test-rg"
-    location            = "eastus"
-    publisher_email     = "admin@example.com"
-    publisher_name      = "Example Publisher"
-    sku_name            = "Developer_1"
-    
+  variables {    
     # Configure an API input with an empty path string to test validation behavior
     apis = {
       test_empty_path = {
@@ -29,10 +30,162 @@ run "validate_empty_api_path" {
   }
 }
 
-run "expect_bad_api_path" {
+run "validate_api_folder_path" {
   command = plan
 
-  # This should succeed if an empty api path is supported
+  # This should succeed if an api path with folder name is supported
+
+  variables {    
+    # Configure an API input with an empty path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test API path with folder"
+        path         = "newpath/newfolder"
+        protocols    = ["https"]
+      }
+    }
+  }
+}
+
+
+# The next 8 tests look at all the invalid values that validation should catch for apis.path
+
+run "expect_bad_api_path_1" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {    
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new*path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_2" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new#path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_3" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new&path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_4" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new+path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_5" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new:path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_6" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new<path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_7" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
 
   variables {
     name                = "test-apim-service"
@@ -42,11 +195,33 @@ run "expect_bad_api_path" {
     publisher_name      = "Example Publisher"
     sku_name            = "Developer_1"
     
-    # Configure an API input with an empty path string to test validation behavior
+    # Configure an API input with an invalid path string to test validation behavior
     apis = {
       test_empty_path = {
-        display_name = "Test Empty Path API"
-        path         = "^*#&+:<>?"
+        display_name = "Test Invalid API Path"
+        path         = "new>path"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}
+
+run "expect_bad_api_path_8" {
+  command = plan
+
+  # This should expect to fail if an invalid api path is passed in
+
+  variables {    
+    # Configure an API input with an invalid path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Invalid API Path"
+        path         = "new?path"
         protocols    = ["https"]
       }
     }

--- a/tests/unit/api_path.tftest.hcl
+++ b/tests/unit/api_path.tftest.hcl
@@ -18,7 +18,7 @@ run "validate_empty_api_path" {
 
   # This should succeed if an empty api path is supported
 
-  variables {    
+  variables {
     # Configure an API input with an empty path string to test validation behavior
     apis = {
       test_empty_path = {
@@ -35,7 +35,7 @@ run "validate_api_folder_path" {
 
   # This should succeed if an api path with folder name is supported
 
-  variables {    
+  variables {
     # Configure an API input with an empty path string to test validation behavior
     apis = {
       test_empty_path = {
@@ -55,7 +55,7 @@ run "expect_bad_api_path_1" {
 
   # This should expect to fail if an invalid api path is passed in
 
-  variables {    
+  variables {
     # Configure an API input with an invalid path string to test validation behavior
     apis = {
       test_empty_path = {
@@ -188,13 +188,6 @@ run "expect_bad_api_path_7" {
   # This should expect to fail if an invalid api path is passed in
 
   variables {
-    name                = "test-apim-service"
-    resource_group_name = "test-rg"
-    location            = "eastus"
-    publisher_email     = "admin@example.com"
-    publisher_name      = "Example Publisher"
-    sku_name            = "Developer_1"
-    
     # Configure an API input with an invalid path string to test validation behavior
     apis = {
       test_empty_path = {
@@ -216,7 +209,7 @@ run "expect_bad_api_path_8" {
 
   # This should expect to fail if an invalid api path is passed in
 
-  variables {    
+  variables {
     # Configure an API input with an invalid path string to test validation behavior
     apis = {
       test_empty_path = {

--- a/tests/unit/api_path.tftest.hcl
+++ b/tests/unit/api_path.tftest.hcl
@@ -1,0 +1,59 @@
+# File: tests/unit/unit.tftest.hcl
+
+# Mock the azurerm provider to prevent real deployments
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "azapi" {}
+
+run "validate_empty_api_path" {
+  command = plan
+
+  # This should succeed if an empty api path is supported
+
+  variables {
+    name                = "test-apim-service"
+    resource_group_name = "test-rg"
+    location            = "eastus"
+    publisher_email     = "admin@example.com"
+    publisher_name      = "Example Publisher"
+    sku_name            = "Developer_1"
+    
+    # Configure an API input with an empty path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Empty Path API"
+        path         = ""
+        protocols    = ["https"]
+      }
+    }
+  }
+}
+
+run "expect_bad_api_path" {
+  command = plan
+
+  # This should succeed if an empty api path is supported
+
+  variables {
+    name                = "test-apim-service"
+    resource_group_name = "test-rg"
+    location            = "eastus"
+    publisher_email     = "admin@example.com"
+    publisher_name      = "Example Publisher"
+    sku_name            = "Developer_1"
+    
+    # Configure an API input with an empty path string to test validation behavior
+    apis = {
+      test_empty_path = {
+        display_name = "Test Empty Path API"
+        path         = "^*#&+:<>?"
+        protocols    = ["https"]
+      }
+    }
+  }
+
+  # Expect the plan or validation to catch the path name restrictions
+  expect_failures = [
+    var.apis
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -321,7 +321,8 @@ DESCRIPTION
   validation {
     condition = alltrue([
       for k, v in var.apis :
-      can(v.path == "" || regex("^[^*#&+:<>?]+$", v.path))
+      length(v.path) == 0 ||
+      can(regex("^[^*#&+:<>?]+$", v.path))
     ])
     error_message = "API path must be empty or must not contain the following characters: *, #, &, +, :, <, >, ?."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -321,9 +321,9 @@ DESCRIPTION
   validation {
     condition = alltrue([
       for k, v in var.apis :
-      can(regex("^[^*#&+:<>?]+$", v.path))
+      can(v.path == "" || regex("^[^*#&+:<>?]+$", v.path))
     ])
-    error_message = "API path cannot contain the following characters: *, #, &, +, :, <, >, ?."
+    error_message = "API path must be empty or must not contain the following characters: *, #, &, +, :, <, >, ?."
   }
   validation {
     condition = alltrue([


### PR DESCRIPTION
… the forbidden characters.

## Description
api.path can be an empty string.  This PR adds validation that the path can be empty, or that it doesn't contain certain characters.

Closes #94

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
